### PR TITLE
Support arbitrary node properties for relationship merges

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = neontology
-version = 0.1.2
+version = 0.1.3
 author = Ontolocy
 description = A Python package for modelling data in a Neo4j graph database.
 long_description = file: README.md

--- a/src/neontology/baserelationship.py
+++ b/src/neontology/baserelationship.py
@@ -67,7 +67,9 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
         """
         return cls.__relationshiptype__  # pyre-ignore[7]
 
-    def _get_merge_parameters(self) -> Dict[str, Any]:
+    def _get_merge_parameters(
+        self, source_prop: str, target_prop: str
+    ) -> Dict[str, Any]:
         """
 
         Returns:
@@ -76,15 +78,12 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
 
         exclusions = {"source", "target"}
 
-        source_pp = self.source.__primaryproperty__
-        target_pp = self.target.__primaryproperty__
-
         # these properties will be referenced individually
         merge_props = self._get_prop_values(self._merge_on, exclude=exclusions)
 
         params = {
-            "source_pp": self.source.neo4j_dict()[source_pp],
-            "target_pp": self.target.neo4j_dict()[target_pp],
+            "source_prop": self.source.neo4j_dict()[source_prop],
+            "target_prop": self.target.neo4j_dict()[target_prop],
             "always_set": self._get_prop_values(self._always_set, exclude=exclusions),
             "set_on_match": self._get_prop_values(
                 self._set_on_match, exclude=exclusions
@@ -95,9 +94,13 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
             **merge_props,
         }
 
+        print(params)
+
         return params
 
-    def merge(self) -> None:
+    def merge(
+        self,
+    ) -> None:
         """Merge this relationship into the database."""
         source_label = self.source.__primarylabel__
         target_label = self.target.__primarylabel__
@@ -105,7 +108,9 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
         source_pp = self.source.__primaryproperty__
         target_pp = self.target.__primaryproperty__
 
-        params = self._get_merge_parameters()
+        params = self._get_merge_parameters(
+            source_prop=source_pp, target_prop=target_pp
+        )
 
         rel_type = self.get_relationship_type()
 
@@ -113,8 +118,8 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
         merge_props = ", ".join([f"{x}: ${x}" for x in self._merge_on])
 
         cypher = f"""
-        MATCH (source:{source_label} {{ {source_pp}: $source_pp }}),
-            (target:{target_label} {{ {target_pp}: $target_pp }})
+        MATCH (source:{source_label} {{ {source_pp}: $source_prop }}),
+            (target:{target_label} {{ {target_pp}: $target_prop }})
         MERGE (source)-[r:{rel_type} {{ {merge_props} }}]->(target)
         ON MATCH SET r += $set_on_match
         ON CREATE SET r += $set_on_create
@@ -131,11 +136,15 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
         rels: List[R],
         source_type: Optional[Type[BaseNode]] = None,
         target_type: Optional[Type[BaseNode]] = None,
+        source_prop: Optional[str] = None,
+        target_prop: Optional[str] = None,
     ) -> None:
         """Merge multiple relationships (of this type) into the database.
 
         Sometimes the source and target label may be ambiguous (e.g. where we have subclassed nodes)
             In this case you can explicitly pass in the relevant types
+
+        Sometimes we want to match nodes on a property which isn't the primary property, so we can specify what property to use.
 
         Args:
             cls (Type[R]): this class
@@ -159,8 +168,11 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
             if type(rel.target) != target_type:
                 raise TypeError("Received an inappropriate kind of target node.")
 
-        source_pp = source_type.__primaryproperty__
-        target_pp = target_type.__primaryproperty__
+        if source_prop is None:
+            source_prop = source_type.__primaryproperty__
+
+        if target_prop is None:
+            target_prop = target_type.__primaryproperty__
 
         source_label = source_type.__primarylabel__
         target_label = target_type.__primarylabel__
@@ -169,21 +181,26 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
         # we need to instantiate the class so that _merge_on is generated as part of __init__
         merge_props = ", ".join([f"{x}: ${x}" for x in cls._get_prop_usage("merge_on")])
 
-        rel_list: List[Dict[str, Any]] = [x._get_merge_parameters() for x in rels]
+        rel_list: List[Dict[str, Any]] = [
+            x._get_merge_parameters(source_prop, target_prop) for x in rels
+        ]
 
         rel_type = cls.get_relationship_type()
 
         cypher = f"""
         UNWIND $rel_list AS rel
         MATCH (source:{source_label})
-        WHERE source.{source_pp} = rel.source_pp
+        WHERE source.{source_prop} = rel.source_prop
         MATCH (target:{target_label})
-        WHERE target.{target_pp} = rel.target_pp
+        WHERE target.{target_prop} = rel.target_prop
         MERGE (source)-[r:{rel_type} {{ {merge_props} }}]->(target)
         ON MATCH SET r += rel.set_on_match
         ON CREATE SET r += rel.set_on_create
         SET r += rel.always_set
         """
+
+        print(cypher)
+        print(rel_list)
 
         graph = GraphConnection()
 
@@ -195,6 +212,8 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
         records: List[Dict[str, Any]],
         source_type: Optional[Type[BaseNode]] = None,
         target_type: Optional[Type[BaseNode]] = None,
+        source_prop: Optional[str] = None,
+        target_prop: Optional[str] = None,
     ) -> None:
         """Take a list of dictionaries and use them to merge in relationships in the graph.
 
@@ -210,6 +229,9 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
             target_type: explicitly state the class to use for target node
         """
 
+        print(f"source prop: {source_prop}")
+        print(f"source prop: {target_prop}")
+
         hydrated_list = []
 
         if source_type is None:
@@ -218,20 +240,37 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
         if target_type is None:
             target_type = cls.__fields__["target"].type_
 
-        source_pp = source_type.__primaryproperty__
-        target_pp = target_type.__primaryproperty__
+        if source_prop is None:
+            source_prop = source_type.__primaryproperty__
+
+        if target_prop is None:
+            target_prop = target_type.__primaryproperty__
 
         for record in records:
             hydrated = dict(record)
 
-            hydrated["source"] = source_type.construct(**{source_pp: record["source"]})
-            hydrated["target"] = target_type.construct(**{target_pp: record["target"]})
+            print(record)
+            print(f"source prop: {source_prop}")
+            print(f"source prop: {target_prop}")
+
+            hydrated["source"] = source_type.construct(
+                **{source_prop: record["source"]}
+            )
+            hydrated["target"] = target_type.construct(
+                **{target_prop: record["target"]}
+            )
 
             hydrated_list.append(hydrated)
 
         rels = [cls(**x) for x in hydrated_list]
 
-        cls.merge_relationships(rels, source_type=source_type, target_type=target_type)
+        cls.merge_relationships(
+            rels,
+            source_type=source_type,
+            source_prop=source_prop,
+            target_type=target_type,
+            target_prop=target_prop,
+        )
 
     @classmethod
     def merge_df(
@@ -239,6 +278,8 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
         df: pd.DataFrame,
         source_type: Optional[Type[BaseNode]] = None,
         target_type: Optional[Type[BaseNode]] = None,
+        source_prop: Optional[str] = None,
+        target_prop: Optional[str] = None,
     ) -> None:
         """Merge in relationships based on data in a pandas data frame
 
@@ -254,4 +295,10 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
         if df.empty is False:
 
             records = df.replace([np.nan], None).to_dict(orient="records")
-            cls.merge_records(records, source_type, target_type)
+            cls.merge_records(
+                records,
+                source_type=source_type,
+                source_prop=source_prop,
+                target_type=target_type,
+                target_prop=target_prop,
+            )

--- a/src/neontology/baserelationship.py
+++ b/src/neontology/baserelationship.py
@@ -94,8 +94,6 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
             **merge_props,
         }
 
-        print(params)
-
         return params
 
     def merge(
@@ -198,9 +196,6 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
         ON CREATE SET r += rel.set_on_create
         SET r += rel.always_set
         """
-
-        print(cypher)
-        print(rel_list)
 
         graph = GraphConnection()
 


### PR DESCRIPTION
Optionally pass through the property name to match on for source/target nodes when creating relationships.