### PR TITLE
Refactor/type hinting generics on standard collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See the [changelog](CHANGELOG.md) or [read the docs](https://neontology.readthed
 ## Example
 
 ```python
-from typing import ClassVar, Optional, list
+from typing import ClassVar, Optional
 import pandas as pd
 from neontology import BaseNode, BaseRelationship, init_neontology, Neo4jConfig
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See the [changelog](CHANGELOG.md) or [read the docs](https://neontology.readthed
 ## Example
 
 ```python
-from typing import ClassVar, Optional, List
+from typing import ClassVar, Optional, list
 import pandas as pd
 from neontology import BaseNode, BaseRelationship, init_neontology, Neo4jConfig
 
@@ -40,7 +40,7 @@ from neontology import BaseNode, BaseRelationship, init_neontology, Neo4jConfig
 class PersonNode(BaseNode):
     __primarylabel__: ClassVar[str] = "Person"
     __primaryproperty__: ClassVar[str] = "name"
-    __secondarylabels__: ClassVar[Optional[List]] = ["Individual", "Somebody"]
+    __secondarylabels__: ClassVar[Optional[list]] = ["Individual", "Somebody"]
     
     name: str
     age: int

--- a/docs/fastapi.md
+++ b/docs/fastapi.md
@@ -23,7 +23,7 @@ First we need to define models for the different types of node we want to store.
 
 ```python
 # main.py
-from typing import ClassVar, Optional, List
+from typing import ClassVar, Optional
 
 from fastapi import FastAPI, HTTPException
 from neontology import BaseNode, BaseRelationship, init_neontology, Neo4jConfig
@@ -125,7 +125,7 @@ Here we'll add some more routes to get the teams that have been created.
 
 ```python
 @app.get("/teams/")
-async def get_teams() -> List[TeamNode]:
+async def get_teams() -> list[TeamNode]:
 
     return TeamNode.match_nodes()
 
@@ -147,7 +147,7 @@ In full, this becomes:
 
 ```python
 # main.py
-from typing import ClassVar, Optional, List
+from typing import ClassVar, Optional
 
 from fastapi import FastAPI, HTTPException
 from neontology import BaseNode, BaseRelationship, init_neontology
@@ -197,7 +197,7 @@ async def create_team(team: TeamNode):
 
 
 @app.get("/teams/")
-async def get_teams() -> List[TeamNode]:
+async def get_teams() -> list[TeamNode]:
 
     return TeamNode.match_nodes()
 
@@ -225,7 +225,7 @@ async def create_team_member(member: TeamMemberNode, team_name: str):
 
 
 @app.get("/team-members/")
-async def get_team_members() -> List[TeamMemberNode]:
+async def get_team_members() -> list[TeamMemberNode]:
 
     return TeamMemberNode.match_nodes()
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ pip install neontology
 ## A Simple Example
 
 ```python
-from typing import ClassVar, Optional, List
+from typing import ClassVar, Optional
 import pandas as pd
 from neontology import BaseNode, BaseRelationship, init_neontology, Neo4jConfig
 

--- a/src/neontology/basenode.py
+++ b/src/neontology/basenode.py
@@ -1,7 +1,7 @@
 import functools
 import json
 import warnings
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, ClassVar, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -23,7 +23,7 @@ def _find_this_node(query, params, node):
 
 def _prepare_related_query(
     node: "BaseNode", wrapped_function: Callable, *args: Any, **kwargs: Any
-) -> Tuple[str, dict]:
+) -> tuple[str, dict]:
     try:
         query, params = wrapped_function(node, *args, **kwargs)
     except ValueError:
@@ -63,7 +63,7 @@ def related_nodes(f: Callable) -> Callable:
     """Decorator to wrap functions on BaseNode subclasses and return a list of nodes."""
 
     @functools.wraps(f)
-    def wrapper(self: "BaseNode", *args: Any, **kwargs: Any) -> List["BaseNode"]:
+    def wrapper(self: "BaseNode", *args: Any, **kwargs: Any) -> list["BaseNode"]:
         new_query, params = _prepare_related_query(self, f, *args, **kwargs)
 
         gc = GraphConnection()
@@ -79,7 +79,7 @@ def related_nodes(f: Callable) -> Callable:
 class BaseNode(CommonModel):  # pyre-ignore[13]
     __primaryproperty__: ClassVar[str]
     __primarylabel__: ClassVar[Optional[str]]
-    __secondarylabels__: ClassVar[List[str]] = []
+    __secondarylabels__: ClassVar[list[str]] = []
 
     def __init__(self, **data: dict):
         super().__init__(**data)
@@ -95,11 +95,11 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
     def __str__(self) -> str:
         return str(self.get_pp())
 
-    def _get_merge_parameters(self) -> Dict[str, Any]:
+    def _get_merge_parameters(self) -> dict[str, Any]:
         """
 
         Returns:
-            Dict[str, Any]: a dictionary of key/value pairs.
+            dict[str, Any]: a dictionary of key/value pairs.
         """
 
         all_props = self.model_dump()
@@ -203,7 +203,7 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
 
         return results[0]
 
-    def merge(self) -> List["BaseNode"]:
+    def merge(self) -> list["BaseNode"]:
         """Merge this node into the graph."""
 
         node_list = [self._get_merge_parameters()]
@@ -219,11 +219,11 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
         return results
 
     @classmethod
-    def create_nodes(cls, nodes: List["BaseNode"]) -> List["BaseNode"]:
+    def create_nodes(cls, nodes: list["BaseNode"]) -> list["BaseNode"]:
         """Create the given nodes in the database.
 
         Args:
-            nodes (List[B]): A list of nodes to create.
+            nodes (list[B]): A list of nodes to create.
 
         Returns:
             list: A list of the primary property values
@@ -247,11 +247,11 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
         return results
 
     @classmethod
-    def merge_nodes(cls, nodes: List["BaseNode"]) -> List["BaseNode"]:
+    def merge_nodes(cls, nodes: list["BaseNode"]) -> list["BaseNode"]:
         """Merge multiple nodes into the database.
 
         Args:
-            nodes (List[B]): A list of nodes to merge.
+            nodes (list[B]): A list of nodes to merge.
 
         Returns:
             list: A list of the primary property values
@@ -273,7 +273,7 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
         return results
 
     @classmethod
-    def merge_records(cls, records: List[dict]) -> List["BaseNode"]:
+    def merge_records(cls, records: list[dict]) -> list["BaseNode"]:
         """Take a list of dictionaries and use them to merge in nodes in the graph.
 
         Each dictionary will be used to merge a node where dictionary key/value pairs
@@ -283,7 +283,7 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
             list: A list of the primary property values
 
         Args:
-            records (List[Dict[str, Any]]): a list of dictionaries of node properties
+            records (list[dict[str, Any]]): a list of dictionaries of node properties
         """
 
         nodes = [cls(**x) for x in records]
@@ -397,7 +397,7 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
     @classmethod
     def match_nodes(
         cls, limit: Optional[int] = None, skip: Optional[int] = None
-    ) -> List["BaseNode"]:
+    ) -> list["BaseNode"]:
         """Get nodes of this type from the database.
 
         Run a MATCH cypher query to retrieve any Nodes with the label of this class.
@@ -407,7 +407,7 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
             skip (int, optional): Skip through this many results (for pagination). Defaults to None.
 
         Returns:
-            Optional[List[B]]: A list of node instances.
+            Optional[list[B]]: A list of node instances.
         """
 
         gc = GraphConnection()

--- a/src/neontology/baserelationship.py
+++ b/src/neontology/baserelationship.py
@@ -1,7 +1,7 @@
 import itertools
 import json
 import warnings
-from typing import Any, ClassVar, Dict, List, Optional, Type, TypeVar
+from typing import Any, ClassVar, Optional, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -23,7 +23,7 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
 
     __relationshiptype__: ClassVar[Optional[str]] = None
 
-    _merge_on: List[str] = (
+    _merge_on: list[str] = (
         PrivateAttr()
     )  # what relationship properties should we merge on
 
@@ -52,7 +52,7 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
         except ValidationError:
             warnings.warn(
                 (
-                    "Relationship Type should contain only alphanumeric characters and underscores."
+                    "Relationship type should contain only alphanumeric characters and underscores."
                     " It should begin with an alphabetic character."
                 )
             )
@@ -74,11 +74,11 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
 
     def _get_merge_parameters(
         self, source_prop: str, target_prop: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
 
         Returns:
-            Dict[str, Any]: a dictionary of key/value pairs.
+            dict[str, Any]: a dictionary of key/value pairs.
         """
 
         exclusions = {"source", "target"}
@@ -151,8 +151,8 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
 
     @classmethod
     def merge_relationships(
-        cls: Type[R],
-        rels: List[R],
+        cls: type[R],
+        rels: list[R],
         source_prop: Optional[str] = None,
         target_prop: Optional[str] = None,
     ) -> None:
@@ -165,8 +165,8 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
         so we can specify what property to use.
 
         Args:
-            cls (Type[R]): this class
-            rels (List[R]): a list of relationships which are instances of this class
+            cls (type[R]): this class
+            rels (list[R]): a list of relationships which are instances of this class
 
         Raises:
             TypeError: If relationships are provided which aren't of this class
@@ -206,7 +206,7 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
                     "Relationship must have a defined relationship type for creating a relationship."
                 )
 
-            rel_list: List[Dict[str, Any]] = [
+            rel_list: list[dict[str, Any]] = [
                 x._get_merge_parameters(source_prop, target_prop) for x in common_rels
             ]
 
@@ -224,10 +224,10 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
 
     @classmethod
     def merge_records(
-        cls: Type[R],
-        records: List[Dict[str, Any]],
-        source_type: Optional[Type[BaseNode]] = None,
-        target_type: Optional[Type[BaseNode]] = None,
+        cls: type[R],
+        records: list[dict[str, Any]],
+        source_type: Optional[type[BaseNode]] = None,
+        target_type: Optional[type[BaseNode]] = None,
         source_prop: Optional[str] = None,
         target_prop: Optional[str] = None,
     ) -> None:
@@ -240,7 +240,7 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
             value of the respective nodes.
 
         Args:
-            records (List[Dict[str, Any]]): a list of dictionaries used to populate relationships
+            records (list[dict[str, Any]]): a list of dictionaries used to populate relationships
             source_type: explicitly state the class to use for source node
             target_type: explicitly state the class to use for target node
         """
@@ -282,10 +282,10 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
 
     @classmethod
     def merge_df(
-        cls: Type[R],
+        cls: type[R],
         df: pd.DataFrame,
-        source_type: Optional[Type[BaseNode]] = None,
-        target_type: Optional[Type[BaseNode]] = None,
+        source_type: Optional[type[BaseNode]] = None,
+        target_type: Optional[type[BaseNode]] = None,
         source_prop: Optional[str] = None,
         target_prop: Optional[str] = None,
     ) -> None:
@@ -313,7 +313,7 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
     @classmethod
     def match_relationships(
         cls, limit: Optional[int] = None, skip: Optional[int] = None
-    ) -> List["BaseRelationship"]:
+    ) -> list["BaseRelationship"]:
         gc = GraphConnection()
         result = gc.match_relationships(cls, limit, skip)
 
@@ -377,8 +377,8 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
     @classmethod
     def neontology_schema(
         cls,
-        source_labels: Optional[List[str]] = None,
-        target_labels: Optional[List[str]] = None,
+        source_labels: Optional[list[str]] = None,
+        target_labels: Optional[list[str]] = None,
     ) -> RelationshipSchema:
         schema_properties = []
         rel_type = cls.__relationshiptype__
@@ -453,5 +453,5 @@ class RelationshipTypeData(BaseModel):
     relationship_class: type[BaseRelationship]
     source_class: type[BaseNode]
     target_class: type[BaseNode]
-    all_source_classes: List[type[BaseNode]]
-    all_target_classes: List[type[BaseNode]]
+    all_source_classes: list[type[BaseNode]]
+    all_target_classes: list[type[BaseNode]]

--- a/src/neontology/commonmodel.py
+++ b/src/neontology/commonmodel.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Set
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr, model_validator
 from pydantic_core import PydanticCustomError
@@ -13,9 +13,9 @@ class CommonModel(BaseModel):
         arbitrary_types_allowed=True,
     )
 
-    _set_on_match: List[str] = PrivateAttr()
-    _set_on_create: List[str] = PrivateAttr()
-    _always_set: List[str] = PrivateAttr()
+    _set_on_match: list[str] = PrivateAttr()
+    _set_on_create: list[str] = PrivateAttr()
+    _always_set: list[str] = PrivateAttr()
 
     def __init__(self, **data: dict):
         super().__init__(**data)
@@ -32,7 +32,7 @@ class CommonModel(BaseModel):
         ]
 
     @classmethod
-    def _get_prop_usage(cls, usage_type: str) -> List[str]:
+    def _get_prop_usage(cls, usage_type: str) -> list[str]:
         all_props = cls.model_json_schema()["properties"]
 
         selected_props = []
@@ -44,12 +44,12 @@ class CommonModel(BaseModel):
         return selected_props
 
     def _get_prop_values(
-        self, props: List[str], exclude: Set[str] = set()
-    ) -> Dict[str, Any]:
+        self, props: list[str], exclude: set[str] = set()
+    ) -> dict[str, Any]:
         """
 
         Returns:
-            Dict[str, Any]: a dictionary of key/value pairs.
+            dict[str, Any]: a dictionary of key/value pairs.
         """
 
         # prop_values = {
@@ -58,7 +58,7 @@ class CommonModel(BaseModel):
 
         return self._engine_dict(exclude=exclude, include=set(props))
 
-    def _engine_dict(self, exclude: Set[str] = set(), **kwargs: Any) -> Dict[str, Any]:
+    def _engine_dict(self, exclude: set[str] = set(), **kwargs: Any) -> dict[str, Any]:
         """Return a dict made up of only types compatible with the GraphEngine
 
         Returns:

--- a/src/neontology/graphconnection.py
+++ b/src/neontology/graphconnection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from warnings import warn
 
 from .graphengines import MemgraphConfig, Neo4jConfig
@@ -119,12 +119,12 @@ class GraphConnection(object):
 
     def create_nodes(
         self, labels: list, pp_key: str, properties: list, node_class: type["BaseNode"]
-    ) -> List["BaseNode"]:
+    ) -> list["BaseNode"]:
         return self.engine.create_nodes(labels, pp_key, properties, node_class)
 
     def merge_nodes(
         self, labels: list, pp_key: str, properties: list, node_class: type["BaseNode"]
-    ) -> List["BaseNode"]:
+    ) -> list["BaseNode"]:
         return self.engine.merge_nodes(labels, pp_key, properties, node_class)
 
     def match_nodes(
@@ -132,7 +132,7 @@ class GraphConnection(object):
         node_class: type["BaseNode"],
         limit: Optional[int] = None,
         skip: Optional[int] = None,
-    ) -> List["BaseNode"]:
+    ) -> list["BaseNode"]:
         return self.engine.match_nodes(node_class, limit, skip)
 
     def match_relationships(
@@ -140,7 +140,7 @@ class GraphConnection(object):
         relationship_class: type["BaseRelationship"],
         limit: Optional[int] = None,
         skip: Optional[int] = None,
-    ) -> List["BaseRelationship"]:
+    ) -> list["BaseRelationship"]:
         return self.engine.match_relationships(relationship_class, limit, skip)
 
     def delete_nodes(self, label: str, pp_key: str, pp_values: list) -> None:
@@ -153,8 +153,8 @@ class GraphConnection(object):
         source_prop: str,
         target_prop: str,
         rel_type: str,
-        merge_on_props: List[str],
-        rel_props: List[dict],
+        merge_on_props: list[str],
+        rel_props: list[dict],
     ) -> None:
         self.engine.merge_relationships(
             source_label,

--- a/src/neontology/graphengines/graphengine.py
+++ b/src/neontology/graphengines/graphengine.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 from pydantic import BaseModel
 
@@ -65,14 +65,14 @@ class GraphEngineBase:
             return value
 
     @classmethod
-    def export_dict_converter(cls, original_dict: Dict[str, Any]) -> Dict[str, Any]:
+    def export_dict_converter(cls, original_dict: dict[str, Any]) -> dict[str, Any]:
         """_summary_
 
         Args:
-            export_dict (Dict[str, Any]): _description_
+            export_dict (dict[str, Any]): _description_
 
         Returns:
-            Dict[str, Any]: _description_
+            dict[str, Any]: _description_
         """
 
         export_dict = original_dict.copy()
@@ -91,13 +91,13 @@ class GraphEngineBase:
     def evaluate_query(
         self,
         cypher: str,
-        params: Dict[str, Any] = {},
+        params: dict[str, Any] = {},
         node_classes: dict = {},
         relationship_classes: dict = {},
     ) -> NeontologyResult:
         raise NotImplementedError
 
-    def evaluate_query_single(self, cypher: str, params: Dict[str, Any]) -> Any:
+    def evaluate_query_single(self, cypher: str, params: dict[str, Any]) -> Any:
         raise NotImplementedError
 
     def apply_constraint(self, label: str, property: str) -> None:
@@ -111,7 +111,7 @@ class GraphEngineBase:
 
     def create_nodes(
         self, labels: list, pp_key: str, properties: list, node_class: type["BaseNode"]
-    ) -> List["BaseNode"]:
+    ) -> list["BaseNode"]:
         """
         Args:
             labels (list): a list of labels to give created nodes
@@ -143,7 +143,7 @@ class GraphEngineBase:
 
     def merge_nodes(
         self, labels: list, pp_key: str, properties: list, node_class: type["BaseNode"]
-    ) -> List["BaseNode"]:
+    ) -> list["BaseNode"]:
         """_summary_
 
         Args:
@@ -176,7 +176,7 @@ class GraphEngineBase:
 
         return results.nodes
 
-    def delete_nodes(self, label: str, pp_key: str, pp_values: List[Any]) -> None:
+    def delete_nodes(self, label: str, pp_key: str, pp_values: list[Any]) -> None:
         cypher = f"""
         UNWIND $pp_values AS pp
         MATCH (n:{gql_identifier_adapter.validate_strings(label)})
@@ -195,8 +195,8 @@ class GraphEngineBase:
         source_prop: str,
         target_prop: str,
         rel_type: str,
-        merge_on_props: List[str],
-        rel_props: List[dict],
+        merge_on_props: list[str],
+        rel_props: list[dict],
     ) -> None:
         # build a string of properties to merge on "prop_name: $prop_name"
         merge_props = ", ".join(
@@ -227,7 +227,7 @@ class GraphEngineBase:
         node_class: type["BaseNode"],
         limit: Optional[int] = None,
         skip: Optional[int] = None,
-    ) -> List["BaseNode"]:
+    ) -> list["BaseNode"]:
         """Get nodes of this type from the database.
 
         Run a MATCH cypher query to retrieve any Nodes with the label of this class.
@@ -237,7 +237,7 @@ class GraphEngineBase:
             skip (int, optional): Skip through this many results (for pagination). Defaults to None.
 
         Returns:
-            Optional[List[B]]: A list of node instances.
+            Optional[list[B]]: A list of node instances.
         """
 
         cypher = f"""
@@ -266,7 +266,7 @@ class GraphEngineBase:
         relationship_class: type["BaseRelationship"],
         limit: Optional[int] = None,
         skip: Optional[int] = None,
-    ) -> List["BaseRelationship"]:
+    ) -> list["BaseRelationship"]:
         """Get nodes of this type from the database.
 
         Run a MATCH cypher query to retrieve any Nodes with the label of this class.
@@ -276,7 +276,7 @@ class GraphEngineBase:
             skip (int, optional): Skip through this many results (for pagination). Defaults to None.
 
         Returns:
-            Optional[List[B]]: A list of node instances.
+            Optional[list[B]]: A list of node instances.
         """
 
         from ..utils import get_node_types, get_rels_by_type

--- a/src/neontology/graphengines/neo4jengine.py
+++ b/src/neontology/graphengines/neo4jengine.py
@@ -1,7 +1,7 @@
 import itertools
 import os
 import warnings
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 from dotenv import load_dotenv
 from neo4j import GraphDatabase
@@ -112,14 +112,14 @@ def neo4j_relationship_to_neontology_rel(
 
 
 def neo4j_records_to_neontology_records(
-    records: List[Neo4jRecord],
+    records: list[Neo4jRecord],
     node_classes: dict,
-    rel_classes: Dict[str, "RelationshipTypeData"],
+    rel_classes: dict[str, "RelationshipTypeData"],
 ) -> tuple:
     new_records = []
 
     for record in records:
-        new_record: Dict[str, dict] = {"nodes": {}, "relationships": {}, "paths": {}}
+        new_record: dict[str, dict] = {"nodes": {}, "relationships": {}, "paths": {}}
 
         for key, entry in record.items():
             if isinstance(entry, Neo4jNode):

--- a/src/neontology/schema_utils.py
+++ b/src/neontology/schema_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 from logging import getLogger
-from typing import Any, List, Optional, Union, get_args, get_origin
+from typing import Any, Optional, Union, get_args, get_origin
 
 from jinja2 import Template
 from pydantic import BaseModel
@@ -27,18 +27,18 @@ class SchemaProperty(BaseModel):
 class RelationshipSchema(BaseModel):
     name: str
     relationship_type: str
-    source_labels: List[str]
-    target_labels: List[str]
+    source_labels: list[str]
+    target_labels: list[str]
 
-    properties: List[SchemaProperty]
+    properties: list[SchemaProperty]
 
 
 class NodeSchema(BaseModel):
     label: str
     title: str
-    secondary_labels: List[str]
-    properties: List[SchemaProperty]
-    outgoing_relationships: List[RelationshipSchema] = []
+    secondary_labels: list[str]
+    properties: list[SchemaProperty]
+    outgoing_relationships: list[RelationshipSchema] = []
 
     def md_node_table(self) -> str:
         """Take a node schema and produce markdown ontology documentation"""
@@ -109,7 +109,7 @@ def extract_type_mapping(
                 if isinstance(entry, type(None)):
                     pass
                 else:
-                    # we do this recursively in case the next layer down is something like List[int]
+                    # we do this recursively in case the next layer down is something like list[int]
                     if show_optional is True:
                         representation = (
                             f"Optional[{extract_type_mapping(entry).representation}]"
@@ -129,7 +129,7 @@ def extract_type_mapping(
     elif get_origin(annotation) == list:
         if len(get_args(annotation)) == 1:
             try:
-                # field type is something like typing.List[str]
+                # field type is something like typing.list[str]
                 representation = str(annotation).split(".")[1]
 
             except IndexError:

--- a/src/neontology/schema_utils.py
+++ b/src/neontology/schema_utils.py
@@ -126,7 +126,7 @@ def extract_type_mapping(
         else:
             raise TypeError(f"Unsupported union type: {annotation}")
 
-    elif get_origin(annotation) == list:
+    elif get_origin(annotation) is list:
         if len(get_args(annotation)) == 1:
             try:
                 # field type is something like typing.list[str]

--- a/src/neontology/tools/import_files.py
+++ b/src/neontology/tools/import_files.py
@@ -1,7 +1,8 @@
 import json
 from logging import getLogger
 from pathlib import Path
-from typing import Generator, List, Optional, Sequence
+from typing import Optional
+from collections.abc import Generator, Sequence
 
 import yaml
 
@@ -10,7 +11,7 @@ from .import_records import import_records
 logger = getLogger(__name__)
 
 
-def _identify_filepaths(input_path: str, path_pattern: str) -> List[Path]:
+def _identify_filepaths(input_path: str, path_pattern: str) -> list[Path]:
     path = Path(input_path)
 
     if path.is_file():

--- a/src/neontology/tools/import_files.py
+++ b/src/neontology/tools/import_files.py
@@ -1,8 +1,8 @@
 import json
+from collections.abc import Generator, Sequence
 from logging import getLogger
 from pathlib import Path
 from typing import Optional
-from collections.abc import Generator, Sequence
 
 import yaml
 

--- a/src/neontology/tools/import_records.py
+++ b/src/neontology/tools/import_records.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from pydantic import BaseModel, model_validator
 
@@ -26,8 +26,8 @@ class NeontologyNodeRaw(BaseModel):
 class NeontologyRelationshipRaw(BaseModel):
     RELATIONSHIP_TYPE: str
     TARGET_LABEL: str
-    TARGET_NODES: Optional[List[NeontologyNodeRaw]] = None
-    TARGETS: Optional[List[str]] = None
+    TARGET_NODES: Optional[list[NeontologyNodeRaw]] = None
+    TARGETS: Optional[list[str]] = None
     TARGET_PROPERTY: Optional[str] = None
 
 
@@ -137,7 +137,7 @@ class NeontologyRelationshipRecord(BaseModel):
         return self
 
 
-def _import_nodes(input_records: List[NeontologyNodeRecord]):
+def _import_nodes(input_records: list[NeontologyNodeRecord]):
     mapped_records = defaultdict(list)
     node_types = get_node_types()
 
@@ -150,7 +150,7 @@ def _import_nodes(input_records: List[NeontologyNodeRecord]):
 
 
 def _import_relationships(
-    input_records: List[NeontologyRelationshipRecord],
+    input_records: list[NeontologyRelationshipRecord],
     check_unmatched: bool,
     error_on_unmatched: bool,
 ):
@@ -230,7 +230,7 @@ def _import_relationships(
 
 def _process_sub_records(
     source_node_record: NeontologyNodeRecord, subrecords
-) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     node_types = get_node_types()
 
     output_nodes = []
@@ -285,7 +285,7 @@ def _process_sub_records(
 
 
 def _prepare_records(
-    input_records: Union[List[Dict[str, Any]], Dict[str, Any]],
+    input_records: Union[list[dict[str, Any]], dict[str, Any]],
 ) -> tuple:
     input_records = input_records.copy()
 

--- a/src/neontology/utils.py
+++ b/src/neontology/utils.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Dict, List, Set, Type
 
 from .basenode import BaseNode
 from .baserelationship import BaseRelationship, RelationshipTypeData
 from .graphconnection import GraphConnection
 
 
-def get_node_types(base_type: Type[BaseNode] = BaseNode) -> Dict[str, Type[BaseNode]]:
+def get_node_types(base_type: type[BaseNode] = BaseNode) -> dict[str, type[BaseNode]]:
     node_types = {}
 
     # if we're starting with a node type that has a primary label, include this in results
@@ -36,7 +35,7 @@ def get_node_types(base_type: Type[BaseNode] = BaseNode) -> Dict[str, Type[BaseN
     return node_types
 
 
-def generate_relationship_type_data(rel_class: Type[BaseRelationship]):
+def generate_relationship_type_data(rel_class: type[BaseRelationship]):
     defined_source_class = rel_class.model_fields["source"].annotation
     defined_target_class = rel_class.model_fields["target"].annotation
 
@@ -53,8 +52,8 @@ def generate_relationship_type_data(rel_class: Type[BaseRelationship]):
 
 
 def get_rels_by_type(
-    base_type: Type[BaseRelationship] = BaseRelationship,
-) -> Dict[str, RelationshipTypeData]:
+    base_type: type[BaseRelationship] = BaseRelationship,
+) -> dict[str, RelationshipTypeData]:
     rel_types: dict = defaultdict(dict)
 
     if (
@@ -93,8 +92,8 @@ def all_subclasses(cls: type) -> set:
 
 
 def get_rels_by_node(
-    base_type: Type[BaseRelationship] = BaseRelationship, by_source: bool = True
-) -> Dict[str, Set[str]]:
+    base_type: type[BaseRelationship] = BaseRelationship, by_source: bool = True
+) -> dict[str, set[str]]:
     if by_source is True:
         node_dir = "source_class"
 
@@ -103,7 +102,7 @@ def get_rels_by_node(
 
     all_rels = get_rels_by_type(base_type)
 
-    by_node: Dict[str, Set[str]] = defaultdict(set)
+    by_node: dict[str, set[str]] = defaultdict(set)
 
     for rel_type, entry in all_rels.items():
         try:
@@ -123,18 +122,18 @@ def get_rels_by_node(
 
 
 def get_rels_by_source(
-    base_type: Type[BaseRelationship] = BaseRelationship,
-) -> Dict[str, Set[str]]:
+    base_type: type[BaseRelationship] = BaseRelationship,
+) -> dict[str, set[str]]:
     return get_rels_by_node(base_type, by_source=True)
 
 
 def get_rels_by_target(
-    base_type: Type[BaseRelationship] = BaseRelationship,
-) -> Dict[str, Set[str]]:
+    base_type: type[BaseRelationship] = BaseRelationship,
+) -> dict[str, set[str]]:
     return get_rels_by_node(base_type, by_source=False)
 
 
-def apply_neo4j_constraints(node_types: List[type[BaseNode]]) -> None:
+def apply_neo4j_constraints(node_types: list[type[BaseNode]]) -> None:
     """Apply constraints based on primary properties for arbitrary set of node types"""
 
     graph = GraphConnection()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,13 @@
 # type: ignore
 
-import os
 import logging
+import os
 
 import pytest
 from dotenv import load_dotenv
 
 from neontology import GraphConnection, init_neontology
-from neontology.graphengines import Neo4jConfig, MemgraphConfig
-
+from neontology.graphengines import MemgraphConfig, Neo4jConfig
 
 logger = logging.getLogger(__name__)
 
@@ -104,9 +103,9 @@ def graph_db(request, tmp_path_factory, get_graph_config):
 
     node_count = gc.evaluate_query_single(cypher)
 
-    assert (
-        node_count == 0
-    ), f"Looks like there are {node_count} nodes in the database, it should be empty."
+    assert node_count == 0, (
+        f"Looks like there are {node_count} nodes in the database, it should be empty."
+    )
 
     yield gc
 

--- a/tests/test_basenode.py
+++ b/tests/test_basenode.py
@@ -1,5 +1,5 @@
 # type: ignore
-from typing import ClassVar, Optional, List
+from typing import ClassVar, Optional
 from datetime import datetime
 from uuid import UUID, uuid4
 
@@ -531,7 +531,7 @@ class ModelTestIntListExplicit(BaseNode):
     __primaryproperty__: ClassVar[str] = "pp"
     __primarylabel__: ClassVar[Optional[str]] = "TestModelIntListExplicit"
     pp: str
-    test_prop_int_list_exp: List[int]
+    test_prop_int_list_exp: list[int]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_basenode.py
+++ b/tests/test_basenode.py
@@ -1,18 +1,18 @@
 # type: ignore
-from typing import ClassVar, Optional
 from datetime import datetime
+from typing import ClassVar, Optional
 from uuid import UUID, uuid4
 
 import pandas as pd
-from pydantic import Field, field_validator, ValidationInfo, field_serializer
 import pytest
+from pydantic import Field, ValidationInfo, field_serializer, field_validator
 
 from neontology import (
     BaseNode,
     BaseRelationship,
-    related_property,
-    related_nodes,
     GQLIdentifier,
+    related_nodes,
+    related_property,
 )
 
 

--- a/tests/test_baserelationship.py
+++ b/tests/test_baserelationship.py
@@ -4,10 +4,8 @@ from typing import ClassVar, Optional
 from uuid import uuid4
 
 import pandas as pd
-from pydantic import Field
 import pytest
-
-from pydantic import ValidationError
+from pydantic import Field, ValidationError
 
 from neontology.basenode import BaseNode
 from neontology.baserelationship import BaseRelationship

--- a/tests/test_commonmodel.py
+++ b/tests/test_commonmodel.py
@@ -1,9 +1,9 @@
 from datetime import datetime
-from uuid import UUID
 from typing import Optional
+from uuid import UUID
 
-from pydantic import Field, ValidationError
 import pytest
+from pydantic import Field, ValidationError
 
 from neontology.commonmodel import CommonModel
 

--- a/tests/test_graph_connection.py
+++ b/tests/test_graph_connection.py
@@ -1,12 +1,11 @@
 from typing import ClassVar, Optional
 
 import pytest
-
 from pydantic import Field
 
-from neontology.graphconnection import GraphConnection
 from neontology.basenode import BaseNode
 from neontology.baserelationship import BaseRelationship
+from neontology.graphconnection import GraphConnection
 
 
 class PracticeNodeGC(BaseNode):

--- a/tests/test_tools/test_import_records.py
+++ b/tests/test_tools/test_import_records.py
@@ -1,5 +1,5 @@
-from typing import ClassVar
 import logging
+from typing import ClassVar
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,15 @@
 from typing import ClassVar, Optional
 
-from neontology.utils import (
-    get_rels_by_source,
-    get_node_types,
-    apply_neo4j_constraints,
-    auto_constrain_neo4j,
-    get_rels_by_type,
-)
 from neontology import GraphConnection
 from neontology.basenode import BaseNode
 from neontology.baserelationship import BaseRelationship
+from neontology.utils import (
+    apply_neo4j_constraints,
+    auto_constrain_neo4j,
+    get_node_types,
+    get_rels_by_source,
+    get_rels_by_type,
+)
 
 
 def test_get_rels_by_source():


### PR DESCRIPTION
Since neontology supports Python3.9 and beyond, should we rely on PEP585 and use type hinting generics from standard collections?