### PR TITLE
Add support for Pydantic Field Aliases for Node/Relationship property names

### DIFF
--- a/src/neontology/basenode.py
+++ b/src/neontology/basenode.py
@@ -101,18 +101,13 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
             dict[str, Any]: a dictionary of key/value pairs.
         """
 
-        all_props = self.model_dump()
+        params = self._get_merge_parameters_common()
+        # get all the properties
+        all_props = params.pop("all_props")
 
-        always_set = {k: all_props[k] for k in self._always_set}
-        set_on_match = {k: all_props[k] for k in self._set_on_match}
-        set_on_create = {k: all_props[k] for k in self._set_on_create}
-
-        params = {
+        params.update({
             "pp": all_props[self.__primaryproperty__],
-            "always_set": always_set,
-            "set_on_match": set_on_match,
-            "set_on_create": set_on_create,
-        }
+        })
 
         return params
 

--- a/src/neontology/baserelationship.py
+++ b/src/neontology/baserelationship.py
@@ -82,29 +82,21 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
 
         exclusions = {"source", "target"}
 
+        params = self._get_merge_parameters_common(exclude=exclusions)
         # get all the properties
-        all_props = self.model_dump(exclude=exclusions)
+        all_props = params.pop("all_props")
 
         # merge_props properties will be referenced individually with kwargs
         merge_props = {k: all_props[k] for k in self._merge_on}
 
-        always_set = {k: all_props[k] for k in self._always_set}
-
-        set_on_match = {k: all_props[k] for k in self._set_on_match}
-
-        set_on_create = {k: all_props[k] for k in self._set_on_create}
-
         source_prop = self.source.model_dump()[source_prop]
         target_prop = self.target.model_dump()[target_prop]
 
-        params = {
+        params.update({
             "source_prop": source_prop,
             "target_prop": target_prop,
-            "always_set": always_set,
-            "set_on_match": set_on_match,
-            "set_on_create": set_on_create,
             **merge_props,
-        }
+        })
 
         return params
 

--- a/src/neontology/graphengines/graphengine.py
+++ b/src/neontology/graphengines/graphengine.py
@@ -57,6 +57,9 @@ class GraphEngineBase:
                     )
 
             return [cls._export_type_converter(x) for x in value]
+        
+        elif value is None:
+            return None
 
         elif isinstance(value, cls._supported_types) is False:
             return str(value)

--- a/tests/test_basenode.py
+++ b/tests/test_basenode.py
@@ -1,11 +1,11 @@
 # type: ignore
 from datetime import datetime
-from typing import ClassVar, Optional
+from typing import Annotated, ClassVar, Optional
 from uuid import UUID, uuid4
 
 import pandas as pd
 import pytest
-from pydantic import Field, ValidationInfo, field_serializer, field_validator
+from pydantic import ConfigDict, Field, ValidationInfo, field_serializer, field_validator
 
 from neontology import (
     BaseNode,
@@ -14,6 +14,7 @@ from neontology import (
     related_nodes,
     related_property,
 )
+from neontology.result import NeontologyResult
 
 
 class PracticeNode(BaseNode):
@@ -998,3 +999,41 @@ def test_create_mass_nodes(use_graph, benchmark):
     benchmark(ComplexPerson.merge_df, people_df)
 
     assert Person.get_count() == 1000
+
+class UserWithAliases(BaseNode):
+    __primaryproperty__: ClassVar[str] = "userName"
+    __primarylabel__: ClassVar[str] = "User"
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+    user_name: Annotated[str, Field(alias='userName')]
+    some_other_property: Annotated[Optional[str],Field(None,alias="otherProperty")]
+
+def test_aliased_properties(use_graph):
+    user1: UserWithAliases = UserWithAliases(userName="User1")
+    user2: UserWithAliases = UserWithAliases(user_name="User2", some_other_property="alpha")
+    user3: UserWithAliases = UserWithAliases(userName="User3", otherProperty="beta")
+    assert user1.user_name == "User1"
+    assert user3.some_other_property == "beta"
+
+    user1.merge()
+    user2.merge()
+    user3.merge()
+
+    cypher = """
+    MATCH (n:User)
+    RETURN n
+    ORDER BY n.userName ASC
+    """
+
+    result: NeontologyResult = use_graph.evaluate_query(cypher)
+    assert result.nodes[0].user_name == "User1"
+    assert hasattr(result.nodes[0],"userName") ==  False
+    assert result.records_raw[0][0]['userName'] == "User1"
+    assert result.nodes[0].some_other_property is None
+    assert result.records_raw[0][0]['otherProperty'] is None
+
+    assert result.nodes[1].user_name == "User2"
+    assert result.nodes[1].some_other_property == "alpha"
+    assert result.records_raw[1][0]['otherProperty'] == "alpha"
+
+    assert result.nodes[2].user_name == "User3"
+    assert result.records_raw[2][0]['otherProperty'] == "beta"


### PR DESCRIPTION
Pydantic Field Aliases allow you to use pythonic_names for your pydantic node/relationship class properties and use aliases to map these properties to the perhaps differently named graphDatabaseNames in the database.

With this example test Node class utilizing Pydantic Field aliases (user_name and some_other_property aliases to userName and otherProperty in the database):
```python
class UserWithAliases(BaseNode):
    __primaryproperty__: ClassVar[str] = "userName"
    __primarylabel__: ClassVar[str] = "User"
    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
    user_name: Annotated[str, Field(alias='userName')]
    some_other_property: Annotated[Optional[str],Field(None,alias="otherProperty")]
```
Exception on merge() in _get_merge_parameters(self): 
```
        params = {
>           "pp": all_props[self.__primaryproperty__],
            "always_set": always_set,
            "set_on_match": set_on_match,
            "set_on_create": set_on_create,
        }
E       KeyError: 'userName'
src\neontology\basenode.py:111: KeyError
```
This PR also:

- Refactors get_merge_parameters to have common base (in commonmodel.py) for nodes and relationships. 
- Fixes bug in GraphEngineBase._export_type_converter() to handle value is None instead of converting None to 'None' string.

New added test and all previous tests are passing for both Neo4J and Memgraph engines.
