### PR TITLE
Relationship match enhancement for classes of same relationship type

### DIFF
--- a/src/neontology/graphengines/graphengine.py
+++ b/src/neontology/graphengines/graphengine.py
@@ -367,16 +367,9 @@ class GraphEngineBase:
             params["limit"] = int_adapter.validate_python(limit)
 
         rel_types = get_rels_by_type(relationship_class)
-        node_classes = get_node_types(
-            relationship_class.model_fields["source"].annotation
-        )
-        if (
-            relationship_class.model_fields["source"].annotation
-            != relationship_class.model_fields["target"].annotation
-        ):
-            node_classes.update(
-                get_node_types(relationship_class.model_fields["target"].annotation)
-            )
+        node_classes = get_node_types(relationship_class.model_fields["source"].annotation)
+        if relationship_class.model_fields["source"].annotation != relationship_class.model_fields["target"].annotation:
+            node_classes.update(get_node_types(relationship_class.model_fields["target"].annotation))
 
         result = self.evaluate_query(
             cypher,

--- a/src/neontology/graphengines/graphengine.py
+++ b/src/neontology/graphengines/graphengine.py
@@ -366,8 +366,17 @@ class GraphEngineBase:
             cypher += " LIMIT $limit "
             params["limit"] = int_adapter.validate_python(limit)
 
-        rel_types = get_rels_by_type()
-        node_classes = get_node_types()
+        rel_types = get_rels_by_type(relationship_class)
+        node_classes = get_node_types(
+            relationship_class.model_fields["source"].annotation
+        )
+        if (
+            relationship_class.model_fields["source"].annotation
+            != relationship_class.model_fields["target"].annotation
+        ):
+            node_classes.update(
+                get_node_types(relationship_class.model_fields["target"].annotation)
+            )
 
         result = self.evaluate_query(
             cypher,

--- a/src/neontology/graphengines/neo4jengine.py
+++ b/src/neontology/graphengines/neo4jengine.py
@@ -128,10 +128,7 @@ def neo4j_relationship_to_neontology_rel(
     tgt_node = neo4j_node_to_neontology_node(neo4j_rel.end_node, node_classes)
 
     # ensure source and target types are allowed for this relationship class
-    if not (
-        (type(src_node) in rel_type_data.all_source_classes)
-        and (type(tgt_node) in rel_type_data.all_target_classes)
-    ):
+    if not ((type(src_node) in rel_type_data.all_source_classes) and (type(tgt_node) in rel_type_data.all_target_classes)):
         return None
 
     rel_props = convert_neo4j_types(dict(neo4j_rel))

--- a/src/neontology/graphengines/neo4jengine.py
+++ b/src/neontology/graphengines/neo4jengine.py
@@ -127,6 +127,13 @@ def neo4j_relationship_to_neontology_rel(
     src_node = neo4j_node_to_neontology_node(neo4j_rel.start_node, node_classes)
     tgt_node = neo4j_node_to_neontology_node(neo4j_rel.end_node, node_classes)
 
+    # ensure source and target types are allowed for this relationship class
+    if not (
+        (type(src_node) in rel_type_data.all_source_classes)
+        and (type(tgt_node) in rel_type_data.all_target_classes)
+    ):
+        return None
+
     rel_props = convert_neo4j_types(dict(neo4j_rel))
     rel_props["source"] = src_node
     rel_props["target"] = tgt_node

--- a/src/neontology/utils.py
+++ b/src/neontology/utils.py
@@ -25,17 +25,12 @@ def get_node_types(
     node_types = {}
 
     # if we're starting with a node type that has a primary label, include this in results
+    # if it has a primary label, it is a concrete class and don't searcch subclasses
     if getattr(base_type, "__primarylabel__", None):
         node_types[base_type.__primarylabel__] = base_type
-
-    for subclass in base_type.__subclasses__():
-        # we can define 'abstract' nodes which don't have a label
-        # these are to provide common properties to be used by subclassed nodes
-        # but shouldn't be put in the graph
-        if getattr(subclass, "__primarylabel__", None):
-            node_types[subclass.__primarylabel__] = subclass
-
-        node_types.update(get_node_types(subclass))
+    else:
+        for subclass in base_type.__subclasses__():
+            node_types.update(get_node_types(subclass))
 
     return node_types
 
@@ -67,22 +62,26 @@ def get_rels_by_type(
 ) -> dict[str, RelationshipTypeData]:
     """Get a dictionary of relationship type data keyed by relationship type.
 
+    This is based on the class hierarchy of BaseRelationship and its subclasses.
+
     Optionally pass in a relationship class to only retrieve classes and subclasses of that type.
+
+    Args:
+        base_type (type[BaseRelationship], optional): Relationship type to return subclass information for. Defaults to BaseRelationship.
+
+    Returns:
+        dict[str, type[BaseRelationship]]: Dictionary of relationship types keyed by __relationshiptype__.    
     """
     rel_types: dict = defaultdict(dict)
 
+    # if we're starting with a relationship type that has a relationshiptype, include this in results
+    # if it has a relationshiptype, it is a concrete class and don't searcch subclasses
     if getattr(base_type, "__relationshiptype__", None):
         rel_types[base_type.__relationshiptype__] = generate_relationship_type_data(base_type)
 
-    for rel_subclass in base_type.__subclasses__():
-        # we can define 'abstract' relationships which don't have a label
-        # these are to provide common properties to be used by subclassed relationships
-        # but shouldn't be put in the graph
-
-        if getattr(rel_subclass, "__relationshiptype__", None):
-            rel_types[rel_subclass.__relationshiptype__] = generate_relationship_type_data(rel_subclass)
-
-        rel_types.update(get_rels_by_type(rel_subclass))
+    else:
+        for rel_subclass in base_type.__subclasses__():
+            rel_types.update(get_rels_by_type(rel_subclass))
 
     return rel_types
 

--- a/src/neontology/utils.py
+++ b/src/neontology/utils.py
@@ -25,12 +25,10 @@ def get_node_types(
     node_types = {}
 
     # if we're starting with a node type that has a primary label, include this in results
-    # if it has a primary label, it is a concrete class and don't searcch subclasses
     if getattr(base_type, "__primarylabel__", None):
         node_types[base_type.__primarylabel__] = base_type
-    else:
-        for subclass in base_type.__subclasses__():
-            node_types.update(get_node_types(subclass))
+    for subclass in base_type.__subclasses__():
+        node_types.update(get_node_types(subclass))
 
     return node_types
 

--- a/src/neontology/utils.py
+++ b/src/neontology/utils.py
@@ -70,7 +70,7 @@ def get_rels_by_type(
         base_type (type[BaseRelationship], optional): Relationship type to return subclass information for. Defaults to BaseRelationship.
 
     Returns:
-        dict[str, type[BaseRelationship]]: Dictionary of relationship types keyed by __relationshiptype__.    
+        dict[str, type[BaseRelationship]]: Dictionary of relationship types keyed by __relationshiptype__.
     """
     rel_types: dict = defaultdict(dict)
 

--- a/tests/test_baserelationship.py
+++ b/tests/test_baserelationship.py
@@ -113,37 +113,37 @@ def test_match_relationship(use_graph):
 
 @pytest.mark.filterwarnings("ignore:Unexpected primary labels returned:UserWarning")
 def test_match_relationship_subclass(use_graph):
-    source_node = PracticeNode(pp="Source Node")
-    source_node.create()
+    person_node = PracticeNode(pp="Source Node")
+    person_node.create()
 
-    target_node = PracticeNode(pp="Target Node")
-    target_node.create()
+    other_person_node = PracticeNode(pp="Target Node")
+    other_person_node.create()
 
-    sub_target_node = SubclassNode(pp="Subclass Target Node", myprop="Sub")
-    sub_target_node.create()
+    employee_node = SubclassNode(pp="Subclass Target Node", myprop="Sub")
+    employee_node.create()
 
     br = PracticeRelationship(
-        source=source_node,
-        target=target_node,
+        source=person_node,
+        target=other_person_node,
         practice_rel_prop="TESTING MATCH RELATIONSHIP",
     )
     br.merge()
 
-    sr = PracticeRelSecondary(
-        source=source_node,
-        target=sub_target_node,
+    sr = PracticeToSubclassOnlyRelationship(
+        source=person_node,
+        target=employee_node,
         practice_rel_prop="TESTING MATCH SUB NODE RELATIONSHIP",
     )
     sr.merge()
 
     rels = PracticeRelationship.match_relationships()
 
-    # should be only 1 Practice Relationship
-    assert len(rels) == 1
+    # should be 2 Practice Relationships (1 of PracticeNode target, 1 of SubclassNode target)
+    assert len(rels) == 2
     assert rels[0].practice_rel_prop == "TESTING MATCH RELATIONSHIP"
 
     # should be only 1 Secondary Relationship
-    rels_secondary = PracticeRelSecondary.match_relationships()
+    rels_secondary = PracticeToSubclassOnlyRelationship.match_relationships()
     assert len(rels_secondary) == 1
     assert rels_secondary[0].practice_rel_prop == "TESTING MATCH SUB NODE RELATIONSHIP"
 
@@ -281,7 +281,7 @@ class NewRelType(BaseRelationship):
     new_rel_prop: str
 
 
-class PracticeRelSecondary(PracticeRelationship):
+class PracticeToSubclassOnlyRelationship(PracticeRelationship):
     """Same as PracticeRelationship, but PracticeNode->SubClassNode instead of PracticeNode->PracticeNode"""
 
     target: SubclassNode


### PR DESCRIPTION
Rebase of #51 to latest develop branch, and focused to only the changes for relationship match enhancements:

Added `test_baserelationship::test_match_relationship_subclass()` to test with a secondary Relationship class that has the same `__relationshiptype__` but different target node class.

(in this PR, made this test completely separate from the original test_match_relationship)

**Details:**

Two relationship classes are defined, where PracticeRelSecondary overrides just the target node class:

```python
class PracticeRelationship(BaseRelationship):
    __relationshiptype__: ClassVar[Optional[str]] = "PRACTICE_RELATIONSHIP"

    source: PracticeNode
    target: PracticeNode

    practice_rel_prop: str = "Default Practice Relationship Property"

class PracticeRelSecondary(PracticeRelationship):
    """Same as PracticeRelationship, but PracticeNode->SubClassNode instead of PracticeNode->PracticeNode"""

    target: SubclassNode
```
_Implementation:_

`graphyengine.py match_relationships()`:

- instead of retrieving all rel_types and node_classes, retrieve only the relevant ones by passing relationship_class for get_rels_by_type and source.annotation and target.annotation classes to get_node_types

`neo4jengine.py neo4j_relationship_to_neontology_rel()`:

- add check that the source and target types are allowed for the relationship class.
 
`utils.py get_node_types()` and `get_rels_by_type()`:

- stop processing node / relationship subclasses when a non-abstract node / relationship is found; simplify logic slightly.
- updated doc string of get_rels_by_type() to match new enhanced doc string of get_node_types()