### PR TITLE
bugfix - source/target forward ref annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.2.2
+
+### Fixed
+
+- Fixed bug where using ForwardRef type annotations for source/target types on a relationship cause errors. Note that ForwardRefs must be resolved before using the relationship (for creation or querying).
+
 ## v2.2.1
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neontology"
-version = "2.2.1"
+version = "2.2.2"
 authors = [
     {name = "Ontolocy"},
 ]

--- a/src/neontology/graphengines/neo4jengine.py
+++ b/src/neontology/graphengines/neo4jengine.py
@@ -110,6 +110,7 @@ def neo4j_relationship_to_neontology_rel(
             (
                 f"Could not find a class for {rel_type} relationship type."
                 " Did you define the class before initializing Neontology?"
+                " Are source and target node classes valid and resolved?"
             )
         )
         return None

--- a/src/neontology/graphengines/networkxengine.py
+++ b/src/neontology/graphengines/networkxengine.py
@@ -136,7 +136,11 @@ def grand_relationship_to_neontology_relationship(
 
         return relationship_classes[rel_type].relationship_class(source=source_node, target=target_node, **rel_dict)
 
-    warnings.warn(f"Relationship type {rel_type} does not match any known classes.")
+    warnings.warn(
+        f"Relationship type {rel_type} does not match any known classes."
+        " Did you define the class before initializing Neontology?"
+        " Are source and target node classes valid and resolved?"
+    )
     return None
 
 


### PR DESCRIPTION
Support cases where source/target nodes are initially defined as ForwardRefs.

Closes #68 